### PR TITLE
Allow multi-word compliment addressees

### DIFF
--- a/src/discryb.cr
+++ b/src/discryb.cr
@@ -33,8 +33,8 @@ module Discryb
         if message.size == 1 && message[0] == "!compliment"
           user = payload.author.username
           reply = "@#{user} #{self.get_compliment}"
-        elsif message.size == 2
-          user = message[1]
+        elsif message.size >= 2
+          user = message[1..].join(" ")
           reply = "#{user}, #{self.get_compliment}"
         end
         if reply


### PR DESCRIPTION
I don't recall why I decided to silently reject messages with longer
addressees.