### PR TITLE
Update discordcr upstream

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,6 @@
 version: 2.0
 shards:
   discordcr:
-    git: https://github.com/discordcr/discordcr.git
-    version: 0.4.0+git.commit.619e08d31fd10918f2554f7623e2066ac308c439
+    git: https://github.com/shardlab/discordcr.git
+    version: 0.4.0+git.commit.d9643cdf7e91f723a80673b0c12071df17938fae
 

--- a/shard.yml
+++ b/shard.yml
@@ -6,8 +6,8 @@ authors:
 
 dependencies:
   discordcr:
-    github: discordcr/discordcr
-    commit: 619e08d31fd10918f2554f7623e2066ac308c439
+    github: shardlab/discordcr
+    tag: v0.4.1
 
 targets:
   discryb:

--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,6 @@ targets:
   instantiate_compliments:
     main: spec/all_combos.cr
 
-crystal: 0.35.1
+crystal: 1.2.2
 
 license: MIT


### PR DESCRIPTION
The discordcr dependency I've been using is no longer maintained, so I'm switching to the new, maintained fork. I also updated the expected Crystal version to 1.2.2 while I was at it.